### PR TITLE
WiFiClient - fast with available caching

### DIFF
--- a/src/WiFiSpiClient.h
+++ b/src/WiFiSpiClient.h
@@ -37,6 +37,8 @@ private:
     uint8_t _sock;   //not used
     uint16_t  _socket;
 
+    int availData = 0;
+
 public:
     WiFiSpiClient();
     WiFiSpiClient(uint8_t sock);


### PR DESCRIPTION
I test sketch upload to SAMD and nRF5 with different libraries and WiFiSpi couldn't make it. Was too slow. This PR makes WiFiSpiClient much faster in typical use with available() checking. 

Additionally read(buffer, size) method should return count of bytes put into buffer, to be useful. Firmware doesn't change the input value of the parameter. I patched it with cached available count. 