### PR TITLE
SSL connection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+0.2.3 (2019-02-18)
+  * SSL Client connection, verifySSL function, protocol 0.2.3
 0.2.0 (2019-01-27)
   * Protocol changed. Status shortened to 2 bytes, added XOR check. Data messages checked by a CRC8.
   * Developed mechanism of confirming and repeating messages.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The library allows Arduino to be client or server on the WiFi network.
 
 ## News
 
+#### 2019-02-18
+
+Added SSL connection to WiFiClient class. Added verifySSL function.
+
 #### 2019-01-27
 
 Enhanced communications protocol (added CRC-8 and confirmation of message reception). Shortened the status message from 4 bytes to 2 bytes and added XOR check. The protocol version is now 0.2.0 and is incompatible with the former one.
@@ -160,6 +164,12 @@ Connects to the specified IP address and port. Returns a value from enum *wl_tcp
 - **int connect(const char *host, uint16_t port)**
 Connects to the specified host and port. Returns a value from enum *wl_tcp_state* (for open connection returns ESTABLISHED).
 
+- **int connectSSL(IPAddress ip, uint16_t port)**
+Connects using SSL to the specified IP address and port. Returns a value from enum *wl_tcp_state* (for open connection returns ESTABLISHED). No authentification checks are performed, recommended to use *verifySSL* function to check the server certificate.
+
+- **int connectSSL(const char *host, uint16_t port)**
+Connects using SSL to the specified host and port. Returns a value from enum *wl_tcp_state* (for open connection returns ESTABLISHED). No authentification checks are performed, recommended to use *verifySSL* function to check the server certificate.
+
 - **uint8_t connected()**
 Returns connection state as a logic value: 1 = connected, 0 = error. Note that the connection could be closed by a server when ESP8266 reads all data in its internal buffer although the master haven't read it yet.
 
@@ -171,6 +181,10 @@ Stops the client (disconnects from the remote server if still connected) and fre
 
 - **operator bool()**
 Returns true when the client is associated with a socket.
+
+- **int verifySSL(uint8_t* fingerprint, const char *host)**
+Verifies server SSL certificate for a fingerprint and domain name. The fingerprint is a 20 byte SHA-1 value certificate fingerprint. It can be read e.g. from web browser examinig the certificate. The parameter *fingerprint* is a 20 byte uint8_t array, it is *not* a character string. The parameter *host* is the domain name of the server we are connecting to.
+
 
 ----------
 
@@ -189,8 +203,11 @@ Peeks into the input queue and returns the first byte in the queue. On error ret
 - **size_t write(uint8_t)**
 Sends one byte to the network. Returns 1 on success, 0 on error.
 
-- **size_t write(const uint8_t *buf, size_t size)**
-Sends the buffer to the network. Returns number of bytes transmitted. Note that on the transmitter side there is usually a buffer so that the data is not guaranteed to be transmit.
+- **size_t write(const void *buf, size_t size)**
+Sends the buffer to the network. Returns number of bytes transmitted.
+
+- **size_t write(const char *str)**
+Sends the character string to the network. Returns number of bytes transmitted.
 
 ### WiFiSpiServer
 

--- a/examples/WiFiWebClientSSL/WiFiWebClientSSL.ino
+++ b/examples/WiFiWebClientSSL/WiFiWebClientSSL.ino
@@ -1,0 +1,145 @@
+/*
+  SSL Web client
+
+ This sketch connects to a website (https://www.example.com)
+ using a WiFi ESP8266 module and checks the validity of the server certificate.
+
+ This example is written for a network using WPA encryption.
+
+ Circuit:
+   1. On ESP8266 must be running (flashed) WiFiSPIESP application.
+    
+   2. Connect the master (Arduino or STM32F103) to the following pins on the esp8266:
+
+            ESP8266         |        |
+    GPIO    NodeMCU   Name  |   Uno  | STM32F103
+  ===============================================
+     15       D8       SS   |   D10  |    PA4
+     13       D7      MOSI  |   D11  |    PA7
+     12       D6      MISO  |   D12  |    PA6
+     14       D5      SCK   |   D13  |    PA5
+
+    Note: If the ESP is booting at the moment when the SPI Master (i.e. Arduino) has the Select line HIGH (deselected)
+    the ESP8266 WILL FAIL to boot!
+    
+ original sketch for WiFi library created 13 July 2010
+ by dlf (Metodo2 srl)
+ modified 31 May 2012
+ by Tom Igoe
+ 
+ modified for WiFiSpi library 14 Mar 2017
+ by Jiri Bilek
+ */
+
+
+#include <WiFiSpi.h>
+
+// WiFi credentials
+char ssid[] = "yourNetwork";        // your network SSID (name)
+char pass[] = "secretPassword";     // your network password (use for WPA)
+
+int status = WL_IDLE_STATUS;
+// if you don't want to use DNS (and reduce your sketch size)
+// use the numeric IP instead of the name for the server:
+//IPAddress server(93,184,216,34);  // numeric IP for www.example.com (no DNS)
+char server[] = "www.example.com";    // name address using DNS
+
+// Initialize the Ethernet client library
+// with the IP address and port of the server
+// that you want to connect to (port 80 is default for HTTP):
+WiFiSpiClient client;
+
+void setup() {
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // Initialize the WifiSpi library
+  WiFiSpi.init();
+
+  // check for the presence of the shield:
+  if (WiFiSpi.status() == WL_NO_SHIELD) {
+    Serial.println("WiFi shield not present");
+    // don't continue:
+    while (true);
+  }
+
+  if (!WiFiSpi.checkProtocolVersion()) {
+    Serial.println("Protocol version mismatch. Please upgrade the firmware");
+    // don't continue:
+    while (true);
+  }
+
+  // attempt to connect to Wifi network:
+  while (status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(ssid);
+    // Connect to WPA/WPA2 network. Change this line if using open network:
+    status = WiFiSpi.begin(ssid, pass);
+  }
+  Serial.println("Connected to wifi");
+  printWifiStatus();
+
+  Serial.println("\nStarting connection to server...");
+  // if you get a connection, report back via serial:
+  if (client.connectSSL(server, 443)) {
+    Serial.println("connected to server");
+    
+    // Verify the server certificate
+    uint8_t fingerprint[] = {0x7B,0xB6,0x98,0x38,0x69,0x70,0x36,0x3D,0x29,0x19,
+                             0xCC,0x57,0x72,0x84,0x69,0x84,0xFF,0xD4,0xA8,0x89};
+    uint8_t vrfy = client.verifySSL(fingerprint, "www.example.com");
+    if (vrfy == 1) {
+        Serial.println("Connection verified");
+        // Make a HTTP request:
+        // Note: client.print() is transmitting one char per a message that is awfully wasting the SPI bus bandwidth
+        //       client.write(char*) is optimized and has minimum overhead
+        client.write("GET / HTTP/1.1\r\n"
+                     "Host: www.example.com\r\n"
+                     "Connection: close\r\n\r\n");
+    }
+    else {
+        Serial.println("Something's wrong, server certificate not verified");
+        client.stop();
+    }
+  }
+}
+
+void loop() {
+  // if there are incoming bytes available
+  // from the server, read them and print them:
+  while (client.available()) {
+    char c = client.read();
+    Serial.write(c);
+  }
+
+  // if the server's disconnected, stop the client:
+  if (!client.connected()) {
+    Serial.println();
+    Serial.println("disconnecting from server.");
+    client.stop();
+
+    // do nothing forevermore:
+    while (true);
+  }
+}
+
+
+void printWifiStatus() {
+  // print the SSID of the network you're attached to:
+  Serial.print("SSID: ");
+  Serial.println(WiFiSpi.SSID());
+
+  // print your WiFi shield's IP address:
+  IPAddress ip = WiFiSpi.localIP();
+  Serial.print("IP Address: ");
+  Serial.println(ip);
+
+  // print the received signal strength:
+  long rssi = WiFiSpi.RSSI();
+  Serial.print("signal strength (RSSI):");
+  Serial.print(rssi);
+  Serial.println(" dBm");
+}

--- a/src/WiFiSpi.cpp
+++ b/src/WiFiSpi.cpp
@@ -33,7 +33,7 @@ extern "C" {
 }
 
 // Protocol version
-const char *WiFiSpiClass::protocolVer = "0.2.0";
+const char *WiFiSpiClass::protocolVer = "0.2.3";
 
 // Hardware reset pin
 int8_t WiFiSpiClass::hwResetPin = -1;

--- a/src/WiFiSpiClient.cpp
+++ b/src/WiFiSpiClient.cpp
@@ -49,7 +49,7 @@ int WiFiSpiClient::connect(const char* host, uint16_t port)
 	IPAddress remote_addr;
 	if (WiFiSpi.hostByName(host, remote_addr))
 	{
-		return connect(remote_addr, port);
+		return _connect(remote_addr, port, false);
 	}
 	return 0;
 }
@@ -59,10 +59,39 @@ int WiFiSpiClient::connect(const char* host, uint16_t port)
  */
 int WiFiSpiClient::connect(IPAddress ip, uint16_t port)
 {
+    return _connect(ip, port, false);
+}
+
+/*
+ * 
+ */
+int WiFiSpiClient::connectSSL(const char* host, uint16_t port)
+{
+  IPAddress remote_addr;
+  if (WiFiSpi.hostByName(host, remote_addr))
+  {
+    return _connect(remote_addr, port, true);
+  }
+  return 0;
+}
+
+/*
+ * 
+ */
+int WiFiSpiClient::connectSSL(IPAddress ip, uint16_t port)
+{
+    return _connect(ip, port, true);
+}
+
+/*
+ * 
+ */
+int WiFiSpiClient::_connect(IPAddress ip, uint16_t port, bool isSSL)
+{
     _sock = WiFiSpiClass::getSocket();
     if (_sock != SOCK_NOT_AVAIL)
     {
-        if (! ServerSpiDrv::startClient(uint32_t(ip), port, _sock))
+        if (! ServerSpiDrv::startClient(uint32_t(ip), port, _sock, (isSSL ? TCP_MODE_WITH_TLS : TCP_MODE)))
             return 0;   // unsuccessfull
 
         WiFiSpiClass::_state[_sock] = _sock;
@@ -194,3 +223,12 @@ WiFiSpiClient::operator bool() {
   return (_sock != SOCK_NOT_AVAIL);
 }
 
+/*
+ * 
+ */
+uint8_t WiFiSpiClient::verifySSL(uint8_t* fingerprint, const char *host) {
+    if (_sock == SOCK_NOT_AVAIL || host[0] == 0)
+        return 0;
+
+    return ServerSpiDrv::verifySSLClient(_sock, fingerprint, host);
+}

--- a/src/WiFiSpiClient.h
+++ b/src/WiFiSpiClient.h
@@ -33,9 +33,7 @@
 class WiFiSpiClient : public Client {
 
 private:
-    //static uint16_t _srcport;
     uint8_t _sock;   //not used
-    //uint16_t  _socket;
 
 public:
     WiFiSpiClient();
@@ -44,6 +42,11 @@ public:
     uint8_t status();
     virtual int connect(IPAddress ip, uint16_t port);
     virtual int connect(const char *host, uint16_t port);
+    virtual int connectSSL(IPAddress ip, uint16_t port);
+    virtual int connectSSL(const char *host, uint16_t port);
+
+    uint8_t verifySSL(uint8_t* fingerprint, const char *host);
+
     virtual size_t write(const uint8_t *buf, size_t size);
     virtual size_t write(uint8_t b)
         { return write(&b, 1); }
@@ -61,6 +64,10 @@ public:
     virtual operator bool();
 
     using Print::write;
+
+private:
+    int _connect(IPAddress ip, uint16_t port, bool isSSL);
+
 };
 
 #endif

--- a/src/utility/srvspi_drv.cpp
+++ b/src/utility/srvspi_drv.cpp
@@ -363,3 +363,30 @@ uint16_t ServerSpiDrv::parsePacket(const uint8_t sock)
 
     return _data16;
 }
+
+/*
+ * Sends verifySSL command
+ * fingerprint - SHA1 of server certificate - must be 20 bytes (not character string!)
+ * host - host name
+ */
+uint8_t ServerSpiDrv::verifySSLClient(const uint8_t sock, uint8_t *fingerprint, const char *host) 
+{
+    // Send Command
+    EspSpiDrv::sendCmd(VERIFY_SSL_CLIENT_CMD, PARAM_NUMS_3);
+    EspSpiDrv::sendParam(fingerprint, 20);
+    EspSpiDrv::sendParam(reinterpret_cast<const uint8_t *>(host), strlen(host));
+    EspSpiDrv::sendParam(sock);
+    EspSpiDrv::endCmd();
+
+    // Wait for reply
+
+    uint8_t _data = 0;
+    uint8_t _dataLen = sizeof(_data);
+    if (!EspSpiDrv::waitResponseCmd(VERIFY_SSL_CLIENT_CMD, PARAM_NUMS_1, &_data, &_dataLen))
+    {
+        WARN(FPSTR(WiFiSpiDrv::ERROR_WAITRESPONSE));
+        _data = 0;
+    }
+
+    return _data;  // return value 1 means ok
+}

--- a/src/utility/srvspi_drv.h
+++ b/src/utility/srvspi_drv.h
@@ -28,7 +28,11 @@
 #include <inttypes.h>
 #include "wifi_spi.h"
 
-typedef enum eProtMode {TCP_MODE, UDP_MODE} tProtMode;
+typedef enum eProtMode {
+    TCP_MODE, 
+    UDP_MODE, 
+    TCP_MODE_WITH_TLS }
+tProtMode;
 
 class ServerSpiDrv
 {
@@ -64,6 +68,8 @@ public:
     static bool beginUdpPacket(uint32_t ip, uint16_t port, uint8_t sock);
 
     static uint16_t parsePacket(const uint8_t sock);
+
+    static uint8_t verifySSLClient(const uint8_t sock, uint8_t *fingerprint, const char *host);
 };
 
 #endif

--- a/src/utility/wifi_spi.h
+++ b/src/utility/wifi_spi.h
@@ -78,6 +78,7 @@ enum {
     SOFTWARE_RESET_CMD       = 0x3F,
 
     GET_PROTOCOL_VERSION_CMD = 0x50,
+    VERIFY_SSL_CLIENT_CMD    = 0x51,
 
     // All command with DATA_FLAG 0x40 send a 16bit Len
 


### PR DESCRIPTION
Add a SSL connection to WiFiSpiClient class.
Connect using function WiFiSpiClient::connectSSL(), verify the server certificate (recommended for avoiding MITM) with WiFiSpiClient::verifySSL().

Adds enhancement described in issue https://github.com/JiriBilek/WiFiSpi/issues/2