### PR TITLE
Fixed missing include for utility/wifispi_drv.h

### DIFF
--- a/src/WiFiSpiClient.cpp
+++ b/src/WiFiSpiClient.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #include "WiFiSpiClient.h"
 #include "utility/wifi_spi.h"
 #include "utility/srvspi_drv.h"
-
+#include "utility/wifispi_drv.h"
 
 WiFiSpiClient::WiFiSpiClient() : _sock(SOCK_NOT_AVAIL) {
 }


### PR DESCRIPTION
Compilation will fail without this include.